### PR TITLE
Tweak styles and add pegs to modal view by default.

### DIFF
--- a/thrive.css
+++ b/thrive.css
@@ -91,7 +91,8 @@
 
 }
 #div-peg-placement {
-	position: relative;
+    position: relative;
+    display: none;
 }
 
 .square {
@@ -183,3 +184,4 @@
 	background-color: green;
 	cursor: pointer;
 }
+

--- a/thrive.css
+++ b/thrive.css
@@ -118,18 +118,19 @@
 .piececolor_ffffff { background-position: -64px 0px;   }
 
 .peg_placement {
-    width: 8px;
-    height: 8px;
+    background-color: limegreen;
+    border-radius: 100%;
+    width: 12px;
+    height: 12px;
     position: absolute;
 	z-index: 2;
 }
 
 .possible_peg_placement {
-    width: 8px;
-    height: 8px;
+    background-color: transparent;
+    border: 1px solid white;
     position: absolute;
 	z-index: 2;
-	background-color: grey;
 	cursor: pointer;
 }
 

--- a/thrive.js
+++ b/thrive.js
@@ -364,6 +364,7 @@ function (dojo, declare) {
 		},
 
 		updatePossiblePegs: function ( possiblePegs, player ) {
+			dojo.style( "div-peg-placement", "display", "block" );
 			dojo.query( '#piece_for_peg_placement' ).addClass( 'piece_' + this.gamedatas.players[ player ].color + '_for_peg_placement' );
 			for ( var peg in possiblePegs ) {
 				dojo.query( '#peg_placement_' + peg ).addClass( 'possible_peg_placement' );
@@ -372,6 +373,7 @@ function (dojo, declare) {
 		
 		cleanPossiblePegs: function( ) {
 			// Remove current possible peg placements
+			dojo.style( "div-peg-placement", "display", "none" );
 			for ( var playr in this.gamedatas.players )
 				dojo.query( '#piece_for_peg_placement' ).removeClass( 'piece_' + this.gamedatas.players[ playr ].color + '_for_peg_placement' );
 			dojo.query( '.possible_peg_placement' ).removeClass( 'possible_peg_placement' );

--- a/thrive.view.php
+++ b/thrive.view.php
@@ -59,31 +59,31 @@
 		for( $n=0; $n<25; $n++ ) {
 			if ( $n != 12 ) {
 				switch( $n ) {
-					case "0": $x = -2; $y = -2 ; break;
-					case "1": $x = -1; $y = -2 ; break;
-					case "2": $x =  0; $y = -2 ; break;
-					case "3": $x =  1; $y = -2 ; break;
-					case "4": $x =  2; $y = -2 ; break;
-					case "5": $x = -2; $y = -1 ; break;
-					case "6": $x = -1; $y = -1 ; break;
-					case "7": $x =  0; $y = -1 ; break;
-					case "8": $x =  1; $y = -1 ; break;
-					case "9": $x =  2; $y = -1 ; break;
-					case "10": $x = -2; $y = 0 ; break;
-					case "11": $x = -1; $y = 0 ; break;
-					case "12": $x =  0; $y = 0 ; break;
-					case "13": $x =  1; $y = 0 ; break;
-					case "14": $x =  2; $y = 0 ; break;
-					case "15": $x = -2; $y = 1 ; break;
-					case "16": $x = -1; $y = 1 ; break;
-					case "17": $x =  0; $y = 1 ; break;
-					case "18": $x =  1; $y = 1 ; break;
-					case "19": $x =  2; $y = 1 ; break;
-					case "20": $x = -2; $y = 2 ; break;
-					case "21": $x = -1; $y = 2 ; break;
-					case "22": $x =  0; $y = 2 ; break;
-					case "23": $x =  1; $y = 2 ; break;
-					case "24": $x =  2; $y = 2 ; break;
+					case "0": $x = -2.1; $y = -2.1 ; break;
+					case "1": $x = -1.1; $y = -2.1 ; break;
+					case "2": $x =  -0.1; $y = -2.1 ; break;
+					case "3": $x =  0.9; $y = -2.1 ; break;
+					case "4": $x =  1.9; $y = -2.1 ; break;
+					case "5": $x = -2.1; $y = -1.1; break;
+					case "6": $x = -1.1; $y = -1.1; break;
+					case "7": $x =  -0.1; $y = -1.1; break;
+					case "8": $x =  0.9; $y = -1.1; break;
+					case "9": $x =  1.9; $y = -1.1; break;
+					case "10": $x = -2.1; $y = -0.1; break;
+					case "11": $x = -1.1; $y = -0.1; break;
+					case "12": $x =  -0.1; $y = -0.1; break;
+					case "13": $x =  0.9; $y = -0.1; break;
+					case "14": $x =  1.9; $y = -0.1; break;
+					case "15": $x = -2.1; $y = 0.9; break;
+					case "16": $x = -1.1; $y = 0.9; break;
+					case "17": $x =  -0.1; $y = 0.9; break;
+					case "18": $x =  0.9; $y = 0.9; break;
+					case "19": $x =  1.9; $y = 0.9; break;
+					case "20": $x = -2.1; $y = 1.9; break;
+					case "21": $x = -1.1; $y = 1.9; break;
+					case "22": $x =  -0.1; $y = 1.9; break;
+					case "23": $x =  0.9; $y = 1.9; break;
+					case "24": $x =  1.9; $y = 1.9; break;
 				}
 
 				$this->page->insert_block( "peg_placement", array(


### PR DESCRIPTION
This is a work-in-progress. Martin and I worked together today to adjust some of the color and presentation around the peg selection state. 

With the current state of these changes, the `#div-peg-placement` container always shows a piece's pegs on the board. We can mitigate this by having a default presentation style (e.g., `style="display: none;"`), and applying a class to that container to remove that style when the right state is activated.

Color contrast between pieces still needs some adjustment, as does the issue of pegs showing in the modal overlay during all board states.
